### PR TITLE
Use struct{} as context value key

### DIFF
--- a/attr.go
+++ b/attr.go
@@ -5,21 +5,17 @@ import (
 	"log/slog"
 )
 
-type ctxkey string
-
-const (
-	attrsKey ctxkey = "ctxlogattrs"
-)
+type ctxkey struct {}
 
 func WithAttrs(ctx context.Context, newAttrs ...slog.Attr) context.Context {
 	// Get fields if set
-	attrs, _ := ctx.Value(attrsKey).([]slog.Attr)
+	attrs, _ := ctx.Value(ctxkey{}).([]slog.Attr)
 	attrs = append(attrs, newAttrs...)
-	ctx = context.WithValue(ctx, attrsKey, attrs)
+	ctx = context.WithValue(ctx, ctxkey{}, attrs)
 	return ctx
 }
 
 func GetAttrs(ctx context.Context) []slog.Attr {
-	attrs, _ := ctx.Value(attrsKey).([]slog.Attr)
+	attrs, _ := ctx.Value(ctxkey{}).([]slog.Attr)
 	return attrs
 }


### PR DESCRIPTION
Using string as context value key is not safe because data with such key can be modified canged somewhere else. Using custom struct as key wil protect from this issue.

See https://pkg.go.dev/context#WithValue
> The provided key must be comparable and should not be of type string or any other built-in type to avoid collisions between packages using context. Users of WithValue should define their own types for keys. To avoid allocating when assigning to an interface{}, context keys often have concrete type struct{}. 