### PR TITLE
Create global attributes

### DIFF
--- a/attr.go
+++ b/attr.go
@@ -5,7 +5,8 @@ import (
 	"log/slog"
 )
 
-type ctxkey struct {}
+type ctxkey struct{}
+type globalctxkey struct{}
 
 func WithAttrs(ctx context.Context, newAttrs ...slog.Attr) context.Context {
 	// Get fields if set
@@ -17,5 +18,63 @@ func WithAttrs(ctx context.Context, newAttrs ...slog.Attr) context.Context {
 
 func GetAttrs(ctx context.Context) []slog.Attr {
 	attrs, _ := ctx.Value(ctxkey{}).([]slog.Attr)
+	globalAttrs, ok := ctx.Value(globalctxkey{}).(*[]slog.Attr)
+	if ok && globalAttrs != nil {
+		attrs = append(attrs, *globalAttrs...)
+	}
 	return attrs
+}
+
+// Global attributes are used to modify the attributes logged by a parent. One
+// example of where this might be useful: Logging middleware that is outside the
+// scope of the request handler:
+//
+// ```
+//
+//	func LogMiddleware(ctx context.Context, h Handler) {
+//	  ctx = ctxlog.InitGlobalAttrs(ctx)
+//	  err := h(ctx)
+//	  if err != nil {
+//	       slog.ErrorContext(ctx, "request failed")
+//	  }
+//	}
+//
+//	func myHandler(ctx context.Context) error {
+//	  ctx = ctxlog.WithGlobalAttrs(ctx, slog.String("request_id", requestId))
+//	  // ...
+//	}
+//
+// ```
+
+// AnchorGlobalAttrs is called to set the "anchor" or root of the global attrs
+// attached to the context. `WithGlobalAttrs` will modify the global attrs up to
+// this point.
+//
+// AnchorGlobalAttrs can be used to anchor global attrs to a given request,
+// rather than the context created at the beginning of the server.
+func AnchorGlobalAttrs(ctx context.Context) context.Context {
+	ctx, _ = initGlobalAttrs(ctx)
+	return ctx
+}
+
+// WithGlobalAttrs attaches "global" attributes to the context that can be read
+// by a parent function. It is useful when a sub-function parses out data that
+// should be logged by the parent later on. For example, logging middleware that
+// exists above the scope of the request handler.
+//
+// If AnchorGlobalAttrs has not been called yet for the given context, the
+// returned context will be set as the anchor point.
+func WithGlobalAttrs(ctx context.Context, newAttrs ...slog.Attr) context.Context {
+	attrs, ok := ctx.Value(globalctxkey{}).(*[]slog.Attr)
+	if !ok {
+		ctx, attrs = initGlobalAttrs(ctx)
+	}
+	*attrs = append(*attrs, newAttrs...)
+	return ctx
+}
+
+func initGlobalAttrs(ctx context.Context) (context.Context, *[]slog.Attr) {
+	globalAttrs := &[]slog.Attr{}
+	ctx = context.WithValue(ctx, globalctxkey{}, globalAttrs)
+	return ctx, globalAttrs
 }

--- a/attr_test.go
+++ b/attr_test.go
@@ -14,14 +14,48 @@ func TestTags(t *testing.T) {
 	attr2 := slog.Int("foo", 5)
 	ctx = ctxlog.WithAttrs(ctx, attr1)
 	ctx = ctxlog.WithAttrs(ctx, attr2)
+
+	// Test global attrs. Use _ = to drop returned context so the global flow
+	// is properly tested.
+	ctx = ctxlog.AnchorGlobalAttrs(ctx)
+	attr3 := slog.Int("bar", 1)
+	attr4 := slog.Int("baz", 2)
+	_ = ctxlog.WithGlobalAttrs(ctx, attr3)
+	_ = ctxlog.WithGlobalAttrs(ctx, attr4)
+
 	attrs := ctxlog.GetAttrs(ctx)
-	if len(attrs) != 2 {
-		t.Fatalf("expected 2 attrs, but got %d instead", len(attrs))
+	if len(attrs) != 4 {
+		t.Fatalf("expected 4 attrs, but got %d instead", len(attrs))
 	}
 	if !attrs[0].Equal(attr1) {
 		t.Fatalf(`expected attr to be %+v but got %+v instead`, attr1, attrs[0])
 	}
 	if !attrs[1].Equal(attr2) {
 		t.Fatalf(`expected attr to be %+v but got %+v instead`, attr2, attrs[1])
+	}
+	if !attrs[2].Equal(attr3) {
+		t.Fatalf(`expected attr to be %+v but got %+v instead`, attr3, attrs[2])
+	}
+	if !attrs[3].Equal(attr4) {
+		t.Fatalf(`expected attr to be %+v but got %+v instead`, attr4, attrs[3])
+	}
+}
+
+func TestWithGlobalAttrsWithoutAnchor(t *testing.T) {
+	ctx := context.Background()
+	attr1 := slog.String("foo", "bar")
+	ctx2 := ctxlog.WithGlobalAttrs(ctx, attr1)
+
+	attrs := ctxlog.GetAttrs(ctx2)
+	if len(attrs) != 1 {
+		t.Fatalf("expected 1 attr, but got %d instead", len(attrs))
+	}
+	if !attrs[0].Equal(attr1) {
+		t.Fatalf(`expected attr to be %+v but got %+v instead`, attr1, attrs[0])
+	}
+
+	attrs = ctxlog.GetAttrs(ctx)
+	if len(attrs) != 0 {
+		t.Fatalf("expected 0 attrs, but got %d instead", len(attrs))
 	}
 }


### PR DESCRIPTION
## Global Attributes

Sometimes you want a sub-function to be able to "pass back" attributes to the parent. An example of this is when using middleware to log errors. In the situation below, the handler `h` may handle parsing the `req` and pull out certain fields that should be logged if there is an error. Unfortunately, because `WithAttrs(...)` only attaches the attrs to a child context, the parent function will not have access to these attrs.

```golang
func logMiddleware(ctx context.Context, h Handler, req []byte) {
    err := h(ctx, req)
    if err != nil {
        slog.ErrorContext(ctx, "request error")
    }
}
```

`ctxlog` provides a way to pass back these attributes for logging through __global attributes__.

```golang
func logMiddleware(ctx context.Context, h Handler, req []byte) {
    // First, set the anchor point/root of global attrs. This allows us to
    // scope global attrs to each request.
    ctx = ctxlog.AnchorGlobalAttrs(ctx) 
    err := h(ctx, req)
    if err != nil {
        slog.ErrorContext(ctx, "request error")
    }
}

func myHandler(ctx context.Context, req []byte) error {
    parsedReq := parseRequest(req)

    // Use ctxlog.WithGlobalAttrs to "pass back" attrs to the anchor point
    ctx = ctxlog.WithGlobalAttrs(ctx, slog.String("request_id", parsedReq.request_id))
    // ...
    return nil
}
```