### PR TITLE
fix race condition in both WithAttrs and WithGlobalAttrs that lead to panic

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,24 +5,23 @@ name: Go
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: 1.21.0
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.21.0
 
-    - name: Build
-      run: go build -v ./...
+      - name: Build
+        run: go build -v ./...
 
-    - name: Test
-      run: go test -v ./...
+      - name: Test
+        run: go test -v -race ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/cyrusaf/ctxlog
 
 go 1.21
+
+retract v1.3.1 // panic if WithAttrs or WithGlobalAttrs called concurrently


### PR DESCRIPTION
This should have been obvious in WithGlobalAttrs, but was more subtle with WithAttrs. Moving to map lead to concurrent writes, while the previous method of using a slice was safe because we were only appending to the slice (which creates a new slice).