### PR TITLE
Subsequent anchor points on a ctx with an existing anchor point should noop

### DIFF
--- a/attr.go
+++ b/attr.go
@@ -33,7 +33,6 @@ func GetAttrs(ctx context.Context) []slog.Attr {
 	}
 	globalAttrMap, ok := ctx.Value(globalctxkey{}).(*atomic.Pointer[map[string]slog.Attr])
 	if ok && globalAttrMap != nil {
-
 		for _, attr := range *globalAttrMap.Load() {
 			attrs = append(attrs, attr)
 		}
@@ -66,9 +65,13 @@ func GetAttrs(ctx context.Context) []slog.Attr {
 // attached to the context. `WithGlobalAttrs` will modify the global attrs up to
 // this point.
 //
-// AnchorGlobalAttrs can be used to anchor global attrs to a given request,
-// rather than the context created at the beginning of the server.
+// If AnchorGlobalAttrs is called on a context with an existing anchor point, it
+// will act as noop and use the original anchor point.
 func AnchorGlobalAttrs(ctx context.Context) context.Context {
+	_, ok := ctx.Value(globalctxkey{}).(*atomic.Pointer[map[string]slog.Attr])
+	if ok {
+		return ctx
+	}
 	ctx, _ = initGlobalAttrs(ctx)
 	return ctx
 }

--- a/attr_test.go
+++ b/attr_test.go
@@ -73,6 +73,29 @@ func TestWithAttrsRace(t *testing.T) {
 	wg.Wait()
 }
 
+func TestSecondAnchor(t *testing.T) {
+	ctx := context.Background()
+
+	// Test global attrs. Use _ = to drop returned context so the global flow
+	// is properly tested.
+	ctx = ctxlog.AnchorGlobalAttrs(ctx)
+	attr1 := slog.String("hello", "world")
+	attr2 := slog.Int("foo", 5)
+	_ = ctxlog.WithGlobalAttrs(ctx, attr1)
+	_ = ctxlog.WithGlobalAttrs(ctx, attr2)
+
+	ctx = ctxlog.AnchorGlobalAttrs(ctx)
+	attr3 := slog.Int("bar", 1)
+	attr4 := slog.Int("baz", 2)
+	_ = ctxlog.WithGlobalAttrs(ctx, attr3)
+	_ = ctxlog.WithGlobalAttrs(ctx, attr4)
+
+	expectedAttrs := []slog.Attr{attr1, attr2, attr3, attr4}
+
+	attrs := ctxlog.GetAttrs(ctx)
+	assertAttrs(t, expectedAttrs, attrs)
+}
+
 func assertAttrs(t *testing.T, expected, actual []slog.Attr) {
 	t.Helper()
 


### PR DESCRIPTION
Previously, if you called `AnchorGlobalAttrs` on a ctx with an existing anchor point, it would reset and clear all existing global attrs. This change chooses not to overwrite the existing anchor point, but rather re-use it. I considered creating a new anchor point and copying over fields, but thought the approach of maintaining the previous anchor point would be more common. We can always add a method to reset the anchor point if that is a needed use case.